### PR TITLE
Further simplification using C#6 features

### DIFF
--- a/MinimalMVVM/ViewModel/DelegateCommand.cs
+++ b/MinimalMVVM/ViewModel/DelegateCommand.cs
@@ -12,18 +12,10 @@ namespace MinimalMVVM.ViewModel
             _action = action;
         }
 
-        public void Execute(object parameter)
-        {
-            _action();
-        }
+        public void Execute(object parameter) => _action();
 
-        public bool CanExecute(object parameter)
-        {
-            return true;
-        }
+        public bool CanExecute(object parameter) => true;
 
-#pragma warning disable 67
         public event EventHandler CanExecuteChanged { add { } remove { } }
-#pragma warning restore 67
     }
 }

--- a/MinimalMVVM/ViewModel/Presenter.cs
+++ b/MinimalMVVM/ViewModel/Presenter.cs
@@ -10,7 +10,7 @@ namespace MinimalMVVM.ViewModel
     {
         private readonly TextConverter _textConverter = new TextConverter(s => s.ToUpper());
         private string _someText;
-        private readonly ObservableCollection<string> _history = new ObservableCollection<string>();
+        public ObservableCollection<string> History { get; } = new ObservableCollection<string>();
 
         public string SomeText
         {
@@ -22,8 +22,6 @@ namespace MinimalMVVM.ViewModel
             }
         }
 
-        public IEnumerable<string> History => _history;
-
         public ICommand ConvertTextCommand => new DelegateCommand(() =>
         {
             if (string.IsNullOrWhiteSpace(SomeText)) return;
@@ -33,8 +31,8 @@ namespace MinimalMVVM.ViewModel
 
         private void AddToHistory(string item)
         {
-            if (!_history.Contains(item))
-                _history.Add(item);
+            if (!History.Contains(item))
+                History.Add(item);
         }
     }
 }


### PR DESCRIPTION
- Replace backing field with C#6's get-only auto-implemented property. Arguably simpler as it does not require separate declaration of getter and backing field.
- Using expression bodied methods in `DelegateCommand` implementation.
- Remove `pragma warning`s as the empty bodies for `add` and `remove` are sufficient (https://blogs.msdn.microsoft.com/trevor/2008/08/14/c-warning-cs0067-the-event-event-is-never-used/)