### PR TITLE
Commenting the fire out of everything

### DIFF
--- a/MinimalMVVM/Models/TextConverter.cs
+++ b/MinimalMVVM/Models/TextConverter.cs
@@ -2,18 +2,33 @@
 
 namespace MinimalMVVM.Models
 {
+    /// <summary>
+    /// This is the entirety of the "business logic" for this program.
+    /// 
+    /// It's a simple class which you pass a conversion function on instantiation, and then use with TextConverterInstance.ConvertText("some text")
+    /// The instance we use is stored in Presenter
+    /// </summary>
     public class TextConverter
     {
-        private readonly Func<string, string> _convertion;
+        // The backend delegate variable which holds the function that does the actual text conversion. Set this on instantiation
+        private readonly Func<string, string> _conversionMethod;
 
-        public TextConverter(Func<string, string> convertion)
+        /// <summary>
+        /// Create an instance of TextConverter, allowing the creator to pass in whatever actual conversion method they want
+        /// </summary>
+        public TextConverter(Func<string, string> conversionMethod)
         {
-            _convertion = convertion;
+            _conversionMethod = conversionMethod;
         }
 
+        /// <summary>
+        /// Run the conversion function put into the private delegate above during instantiation, and return its output (the converted text)
+        /// </summary>
+        /// <param name="inputText"></param>
+        /// <returns></returns>
         public string ConvertText(string inputText)
         {
-            return _convertion(inputText);
+            return _conversionMethod(inputText);
         }
     }
 }

--- a/MinimalMVVM/ViewModels/DelegateCommand.cs
+++ b/MinimalMVVM/ViewModels/DelegateCommand.cs
@@ -3,12 +3,20 @@ using System.Windows.Input;
 
 namespace MinimalMVVM.ViewModels
 {
+    /// <summary>
+    /// Extremely simple implementation of a delegate command (aka relay command).
+    /// - _action : points to the "business" method that the command actually runs
+    /// - Execute() : takes the object parameter required by the ICommand interface, then runs _action(). Basically a wrapper.
+    /// - CanExecute() : tells whether the command can be run or not. It always returns true, because this is a really simple implementation of a relay command which essentially creates a command from a method.
+    /// - CanExecuteChanged : this does nothing since CanExecute is always true, but we have to include it since it's part of the ICommand interface spec.
+    /// </summary>
     public class DelegateCommand : ICommand
     {
         private readonly Action _action;
 
         public DelegateCommand(Action action)
         {
+            // Put the Action (basically a void method) passed as a parameter into our private field _action, where it can be run by the Execute function when the command is called
             _action = action;
         }
 
@@ -17,11 +25,13 @@ namespace MinimalMVVM.ViewModels
             _action();
         }
 
+
         public bool CanExecute(object parameter)
         {
             return true;
         }
 
+        // This essentially means when someone subscribes to this event, do nothing, since the event never needs to fire (because CanExecute is always true).
 #pragma warning disable 67
         public event EventHandler CanExecuteChanged { add { } remove { } }
 #pragma warning restore 67

--- a/MinimalMVVM/ViewModels/ObservableObject.cs
+++ b/MinimalMVVM/ViewModels/ObservableObject.cs
@@ -1,16 +1,31 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 
 namespace MinimalMVVM.ViewModels
 {
+    // This implements the INotifyPropertyChanged interface in a simple way to make objects provide data-binding property change notifications
+    // To use, base a class on ObservableObject, then call RaisedPropertyChangedEvent("myPropertyName") in the set method for your property
     public abstract class ObservableObject : INotifyPropertyChanged
     {
+        // Make an event handler using (pre-existing?) PropertyChangedEventHandler delegate.
+        // This defines the signature ("shape") of the functions that can be subscribed to this event.
+        // Data-Bindings will "subscribe" to this event
         public event PropertyChangedEventHandler PropertyChanged;
 
+        // A method that's inherited by any child of this class, which is fired (using get{} and set{}) whenever a property is changed in the child class
+        // This "raises the event", or runs all the functions "subscribed", e.g. all the functions listed in the PropertyChanged event handler
         protected void RaisePropertyChangedEvent(string propertyName)
         {
+            // Set handler to the PropertyChanged event
             var handler = PropertyChanged;
+            // Make sure the event is not empty
+            // i.e. make sure the list of functions to run when this event fires is not empty (meaning no subscribers to the event)
             if (handler != null)
-                handler(this, new PropertyChangedEventArgs(propertyName));
+                // Fire the PropertyChanged event for this instance of ObservableObject (with the propertyName provided in the call to RaisePropertyChangedEvent)
+                handler.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+            // For the sake of clarity, I have added a simple Console log here so you can see when the event fires
+            Console.WriteLine("PropertyChange raised for the " + propertyName + " property of an instance of " + this);
         }
     }
 }

--- a/MinimalMVVM/ViewModels/ObservableObject.cs
+++ b/MinimalMVVM/ViewModels/ObservableObject.cs
@@ -3,8 +3,13 @@ using System.ComponentModel;
 
 namespace MinimalMVVM.ViewModels
 {
-    // This implements the INotifyPropertyChanged interface in a simple way to make objects provide data-binding property change notifications
-    // To use, base a class on ObservableObject, then call RaisedPropertyChangedEvent("myPropertyName") in the set method for your property
+    /// <summary>
+    /// Implements INotifyPropertyChanged interface in a simple way to make objects provide 
+    /// data-binding property change notifications.
+    /// </summary>
+    /// <remarks>
+    /// To use, base a class on ObservableObject, then call RaisedPropertyChangedEvent("myPropertyName") in the set method for your property
+    /// </remarks>
     public abstract class ObservableObject : INotifyPropertyChanged
     {
         // Make an event handler using (pre-existing?) PropertyChangedEventHandler delegate.
@@ -27,7 +32,7 @@ namespace MinimalMVVM.ViewModels
                 handler.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
             // For the sake of clarity, I have added a simple Console log here so you can see when the event fires
-            Console.WriteLine("PropertyChange raised for the " + propertyName + " property of an instance of " + this);
+            Debug.WriteLine("PropertyChange raised for the " + propertyName + " property of an instance of " + this);
         }
     }
 }

--- a/MinimalMVVM/ViewModels/ObservableObject.cs
+++ b/MinimalMVVM/ViewModels/ObservableObject.cs
@@ -17,6 +17,8 @@ namespace MinimalMVVM.ViewModels
         protected void RaisePropertyChangedEvent(string propertyName)
         {
             // Grab the PropertyChanged handler we define previously
+            // This is done because PropertyChanged can become null if a subscriber unsubscribes after the null check but before the invocation.
+            // This way we still have a non-null copy, that won't cause problems, to work with.
             var handler = PropertyChanged;
             // Make sure the event is not empty
             // i.e. make sure the list of functions to run when this event fires is not empty (meaning no subscribers to the event)

--- a/MinimalMVVM/ViewModels/ObservableObject.cs
+++ b/MinimalMVVM/ViewModels/ObservableObject.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 namespace MinimalMVVM.ViewModels
 {
     /// <summary>
-    /// Implements INotifyPropertyChanged interface in a simple way to make objects provide 
+    /// Implements INotifyPropertyChanged interface in a simple way to make objects provide
     /// data-binding property change notifications.
     /// </summary>
     /// <remarks>

--- a/MinimalMVVM/ViewModels/ObservableObject.cs
+++ b/MinimalMVVM/ViewModels/ObservableObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace MinimalMVVM.ViewModels
 {

--- a/MinimalMVVM/ViewModels/ObservableObject.cs
+++ b/MinimalMVVM/ViewModels/ObservableObject.cs
@@ -13,10 +13,10 @@ namespace MinimalMVVM.ViewModels
         public event PropertyChangedEventHandler PropertyChanged;
 
         // A method that's inherited by any child of this class, which is fired (using get{} and set{}) whenever a property is changed in the child class
-        // This "raises the event", or runs all the functions "subscribed", e.g. all the functions listed in the PropertyChanged event handler
+        // This "raises the event", or runs all the functions "subscribed", i.e. all the functions listed in the PropertyChanged event handler
         protected void RaisePropertyChangedEvent(string propertyName)
         {
-            // Set handler to the PropertyChanged event
+            // Grab the PropertyChanged handler we define previously
             var handler = PropertyChanged;
             // Make sure the event is not empty
             // i.e. make sure the list of functions to run when this event fires is not empty (meaning no subscribers to the event)

--- a/MinimalMVVM/ViewModels/Presenter.cs
+++ b/MinimalMVVM/ViewModels/Presenter.cs
@@ -1,47 +1,116 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows.Input;
 using MinimalMVVM.Models;
 
 namespace MinimalMVVM.ViewModels
 {
-    public class Presenter : ObservableObject
-    {
-        private readonly TextConverter _textConverter = new TextConverter(s => s.ToUpper());
-        private string _someText;
-        private readonly ObservableCollection<string> _history = new ObservableCollection<string>();
+    /*
+     * HOW IT WORKS:
+     * 1. When you type into the input TextBox, you're actually setting the Presenter class's SomeText property (via data binding). Watch the debug console to see the PropertyChange events firing when you type
+     * 2. When you click the "Convert" button (or press enter) you are running the Command specified in the convert button's Command property.
+     *      - This is data-bound to Presenter's ConvertTextCommand, which returns an instance of DelegateCommand (see relevant region below)
+     *      - So when you click the button or press enter, you are running ConvertTextCommand.Execute()
+     *      - ConvertTextCommand.Execute() ends up pointing to Presenter.ConvertText()
+     *          - When Presenter.ConvertText() is called, it shoves Presenter.SomeText through Presenter._textConverter.ConvertText(), which returns the converted all-caps string
+     *          - Then Presenter.ConvertText() adds the converted string to Presenter._history, which is data bound (via the Presenter.History property) to the history ListBox in the XAML UI
+    */ 
 
+    // The contents of Presenter are best understood when read from top to bottom!
+    // It's easy to miss, but the actual instance of Presenter that we use is created in XAML, not code-behind, in ConvertWindow.xaml
+    public class Presenter : ObservableObject // Base on the ObservableObject class so simple properties will play nice with data binding (see ObservableObject.cs)
+    {
+        #region Private TextConverter Instance
+        // Create an instance of TextConverter, using an anonymous method as a parameter to pass in the conversion function since it's so simple
+        private readonly TextConverter _textConverter = new TextConverter(
+            delegate(string s)
+            {
+                // Uncomment to see when this runs
+                //Console.WriteLine("Anonymous method within TextConverter instance ran!");
+
+                return s.ToUpper();
+            }
+        );
+        // ^^^This could be made way shorter using lambda expressions as below, but for the sake of clarity I have included the more verbose, non-lambda way. Both ways give the same result.
+        // private readonly TextConverter _textConverter = new TextConverter(s => s.ToUpper());
+        #endregion
+
+        #region SomeText (User Input) Property
+        // SomeText is the property the input TextBox is data-bound to
+        // _someText is just the backend variable for SomeText
+        private string _someText;
         public string SomeText
         {
             get { return _someText; }
+
+            // This is called (because of the binding) each time the user changes the contents of the input TextBox
             set
             {
+                // Set backend variable
                 _someText = value;
+                // Raise the property changed event for the property "SomeText"
                 RaisePropertyChangedEvent("SomeText");
             }
         }
+        #endregion
 
+        #region History ObservableCollection
+
+        // Create a backend ObservableCollection variable, which is basically a WPF Data-binding-friendly List
+        // ObservableCollections implement the INotifyPropertyChanged interface so they play nice with bindings
+        private readonly ObservableCollection<string> _history = new ObservableCollection<string>();
+
+        // This is basically a wrapper to prevent external entities from being able to write to _history
+        // The ListBox history display in the XAML is bound to this property
         public IEnumerable<string> History
         {
             get { return _history; }
         }
 
-        public ICommand ConvertTextCommand
-        {
-            get { return new DelegateCommand(ConvertText); }
-        }
+        #endregion
 
+        #region AddToHistory Method
+        // Add a string of text to our History ObservableCollection
+        // which will consequently add it to the data-bound history display in the UI
+        private void AddToHistory(string item)
+        {
+            // If this item doesn't already contain this item...
+            if (!_history.Contains(item))
+                // Add it to the private backend _history ObservableCollection, which is publicly accessible through the IEnumerable History property
+                _history.Add(item);
+        }
+        #endregion
+
+        #region ConvertText Command and Delegate Function
+
+        // This method runs our SomeText property through our TextConverter instance,
+        // Then adds the converted text to our History ObservableCollection (and thus the history ListBox) using AddToHistory()
+        // This is the method which will be passed to an instance of the DelegateCommand class, essentially encapsulating this method in a WPF Command
         private void ConvertText()
         {
-            if (string.IsNullOrWhiteSpace(SomeText)) return;
+            // If this ViewModel (this class)'s SomeText property is empty, do nothing
+            if (string.IsNullOrWhiteSpace(SomeText))
+                return;
+            // Otherwise use our private TextConverter instance to convert the text, and then add it to the History ObservableCollection
             AddToHistory(_textConverter.ConvertText(SomeText));
+            // Then clear the SomeText property, which consequently clears the data-bound input TextBox
             SomeText = string.Empty;
         }
 
-        private void AddToHistory(string item)
+        // This is where the Command binding points on the "Convert" button in the XAML
+        // This uses the DelegateCommand class to encapsulate the ConvertText method (above) in a WPF Command
+        public ICommand ConvertTextCommand
         {
-            if (!_history.Contains(item))
-                _history.Add(item);
+            get
+            {
+                // More under the hood info about DelegateCommand can be found in DelegateCommand.cs, but this basically slides ConvertText in as the Execute() method of the command
+                // If you're not familiar with commands, you should learn them, but for now just understand that whatever function you pass to DelegateCommand's constructor
+                // (in this case, ConvertText) will run when the button data-bound to this command is pressed
+                return new DelegateCommand(ConvertText);
+            }
         }
+
+        #endregion
     }
 }

--- a/MinimalMVVM/ViewModels/Presenter.cs
+++ b/MinimalMVVM/ViewModels/Presenter.cs
@@ -17,8 +17,7 @@ namespace MinimalMVVM.ViewModels
      *
      * The contents of Presenter are best understood when read from top to bottom.
      * It's easy to miss, but the actual instance of Presenter that we use is created in XAML, not code-behind, in ConvertWindow.xaml
-    */
-    
+     */
     /// <summary>
     /// Viewmodel for our application, based on <see cref="ObservableObject"/> so simple properties will play nice with data binding.
     /// </summary>

--- a/MinimalMVVM/ViewModels/Presenter.cs
+++ b/MinimalMVVM/ViewModels/Presenter.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows.Input;
@@ -15,25 +14,24 @@ namespace MinimalMVVM.ViewModels
      *      - ConvertTextCommand.Execute() ends up pointing to Presenter.ConvertText()
      *          - When Presenter.ConvertText() is called, it shoves Presenter.SomeText through Presenter._textConverter.ConvertText(), which returns the converted all-caps string
      *          - Then Presenter.ConvertText() adds the converted string to Presenter._history, which is data bound (via the Presenter.History property) to the history ListBox in the XAML UI
-    */ 
-
-    // The contents of Presenter are best understood when read from top to bottom!
-    // It's easy to miss, but the actual instance of Presenter that we use is created in XAML, not code-behind, in ConvertWindow.xaml
-    public class Presenter : ObservableObject // Base on the ObservableObject class so simple properties will play nice with data binding (see ObservableObject.cs)
+     *
+     * The contents of Presenter are best understood when read from top to bottom.
+     * It's easy to miss, but the actual instance of Presenter that we use is created in XAML, not code-behind, in ConvertWindow.xaml
+    */
+    
+    /// <summary>
+    /// Viewmodel for our application, based on <see cref="ObservableObject"/> so simple properties will play nice with data binding.
+    /// </summary>
+    public class Presenter : ObservableObject
     {
         #region Private TextConverter Instance
         // Create an instance of TextConverter, using an anonymous method as a parameter to pass in the conversion function since it's so simple
-        private readonly TextConverter _textConverter = new TextConverter(
-            delegate(string s)
-            {
-                // Uncomment to see when this runs
-                //Console.WriteLine("Anonymous method within TextConverter instance ran!");
+        private readonly TextConverter _textConverter = new TextConverter(s => {
+            // Uncomment to see when this runs
+            //Debug.WriteLine("Anonymous method within TextConverter instance ran!");
 
-                return s.ToUpper();
-            }
-        );
-        // ^^^This could be made way shorter using lambda expressions as below, but for the sake of clarity I have included the more verbose, non-lambda way. Both ways give the same result.
-        // private readonly TextConverter _textConverter = new TextConverter(s => s.ToUpper());
+            return s.ToUpper();
+        });
         #endregion
 
         #region SomeText (User Input) Property
@@ -58,7 +56,7 @@ namespace MinimalMVVM.ViewModels
         #region History ObservableCollection
 
         // Create a backend ObservableCollection variable, which is basically a WPF Data-binding-friendly List
-        // ObservableCollections implement the INotifyPropertyChanged interface so they play nice with bindings
+        // ObservableCollections implement the INotifyPropertyChanged and INotifyCollectionChanged interfaces so they play nice with bindings
         private readonly ObservableCollection<string> _history = new ObservableCollection<string>();
 
         // This is basically a wrapper to prevent external entities from being able to write to _history

--- a/MinimalMVVM/Views/ConvertWindow.xaml
+++ b/MinimalMVVM/Views/ConvertWindow.xaml
@@ -8,6 +8,7 @@
         ResizeMode="NoResize"
         SizeToContent="WidthAndHeight">
     
+    <!--Set Window.DataContext to an instance of the Presenter class-->
     <Window.DataContext>
         <ViewModels:Presenter/>
     </Window.DataContext>

--- a/MinimalMVVM/Views/ConverterControl.xaml
+++ b/MinimalMVVM/Views/ConverterControl.xaml
@@ -15,9 +15,18 @@
     
     <StackPanel Height="336">
         <Label Foreground="Blue" Margin="5,5,5,0">Text To Convert</Label>
+        
+        <!--TextBox data-bound to Presenter.SomeText, with UpdateSourceTrigger set to update the SomeText property
+        whenever the input property changes, not just when you unfocus the TextBox (that's the default in WPF)-->
         <TextBox Text="{Binding SomeText, UpdateSourceTrigger=PropertyChanged}" Margin="5"/>
         <Label Foreground="Blue" Margin="5,5,5,0">History</Label>
+        
+        <!--ListBox.ItemsSource is bound to the ObservableCollection Presenter.History-->
         <ListBox ItemsSource="{Binding History}" Height="200" Margin="5"/>
+        
+        <!--Button.Command is data-bound to Presenter.ConvertTextCommand, which is an instance of DelegateCommand.
+        For those not familiar with WPF Commands, this basically means Presenter.ConvertText() is run when Convert is clicked
+        (More detail in Presenter.cs and DelegateCommand.cs)-->
         <Button Command="{Binding ConvertTextCommand}" Margin="5">Convert</Button>
     </StackPanel>
     

--- a/README.md
+++ b/README.md
@@ -6,7 +6,3 @@ worlds-simplest-csharp-wpf-mvvm-example
 The World's Simplest C# WPF MVVM Example as described [here](http://www.markwithall.com/programming/2013/03/01/worlds-simplest-csharp-wpf-mvvm-example.html).
 
 A C# 6 version of the code can be found in the [C#6.0 branch](https://github.com/MarkWithall/worlds-simplest-csharp-wpf-mvvm-example/tree/C%236.0).
-
----
-
-I didn't modify the structure of this program from the original creator, I just added a whole bunch of comments to better describe it. As a newbie to C#, this turned out to be a great example to learn from, but it was way harder than it should've been to get a handle on how it worked since there were no comments in the actual code. This is my attempt to remedy that. PR's welcome!

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ worlds-simplest-csharp-wpf-mvvm-example
 The World's Simplest C# WPF MVVM Example as described [here](http://www.markwithall.com/programming/2013/03/01/worlds-simplest-csharp-wpf-mvvm-example.html).
 
 A C# 6 version of the code can be found in the [C#6.0 branch](https://github.com/MarkWithall/worlds-simplest-csharp-wpf-mvvm-example/tree/C%236.0).
+
+---
+
+I didn't modify the structure of this program from the original creator, I just added a whole bunch of comments to better describe it. As a newbie to C#, this turned out to be a great example to learn from, but it was way harder than it should've been to get a handle on how it worked since there were no comments in the actual code. This is my attempt to remedy that. PR's welcome!


### PR DESCRIPTION
I found this as a newbie C# dev, and it was very helpful to have a simple example of how to actually _implement_ MVVM in C#/WPF. However, it made it unnecessarily difficult to understand having no comments. I eventually got it from the online docs, but it would've been so much better to be able to click around within Visual Studio and see every detail spelled out in comments. This is that. I changed a couple variable names for clarity, and adjusted the order of definition in some of the classes so they all read pretty easily from top to bottom, but 90% of the changes here are comments.

Thanks for doing this example, it was super helpful!